### PR TITLE
Make Crypt::JWT decode failure test work with both 0.021 and 0.023+

### DIFF
--- a/t/decode_args.t
+++ b/t/decode_args.t
@@ -180,7 +180,7 @@ subtest 'some bad tokens' => sub {
                     Authorization => "Bearer " . $jwt_bad_secret
                 );
                 is( $res->code, 401, 'status 401' );
-                like( $res->content, qr/decode failed/, 'cannot decode' );
+                like( $res->content, qr/(?:decode failed|cannot decode)/i, 'cannot decode' );
             };
 
             subtest 'expired token' => sub {


### PR DESCRIPTION
See https://rt.cpan.org/Ticket/Display.html?id=127893&results=2d5a29f45d40d0956cf78dd37339b633
If Crypt::JWT 0.023 or 0.024 is installed (instead of 0.021), installing Plack::Middleware::Auth::JWT fails on tests which check for specific text in the error message, this change updates that check to use both the 0.021 and 0.023 versions of the error message